### PR TITLE
Rework docker content

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
-version: '3.6'
+version: '3.7'
 services:
   cpcache:
     build: .
-    image: cpcache
-    network_mode: host
-    stdin_open: true
-    tty: true
+    ports:
+      - 7070:7070
+    volumes:
+      - cpcache_cache:/var/cache/cpcache
+
+volumes:
+  cpcache_cache:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p /var/cache/cpcache/pkg/{community,community-staging,community-testing,core,extra,gnome-unstable,kde-unstable,multilib,multilib-testing,staging,testing}/os/x86_64
+mkdir -p /var/cache/cpcache/state
+
+/var/lib/cpcache/bin/cpcache start
+


### PR DESCRIPTION
This PR updates the available docker content to be more "publish friendly". I think it would be great if cpcache had an official dockerhub image.

I am moving to a new Ubuntu-based router and wanted to use cpcache dockerized. There were two reasons for me to start this work:
1) The main Dockerfile builds an image, which is more a testing environment, than a finished packaged application.  For instance, it should run with an interactive shell. Additionally, the image is rather big.
1) A cpcache docker image is available on dockerhub https://hub.docker.com/r/improwised/cpcache , but this appears to be just a copy & paste of the Dockerfile from this repo with all the issues.

As I know nothing about elixir, I have taken heavy inspiration from your own AUR package. Here is a screenshot comparison of image size produced:
![image](https://user-images.githubusercontent.com/2943282/77192955-b4b07000-6add-11ea-8234-0faa202ce9a6.png)


The proposed version is missing one more important step to consider it "cloud-ready" -> environment based configuration. I could have written a wrapper around the main `toml` config, but I figured that if you really wanted to go through this exercise properly, it would be much better to adjust the application itself to take its config via environment vars.

Let me know what you think. I've been using my version a few days serving all my arch machines and it works like a charm.